### PR TITLE
feat: optimize GraphQL request logging

### DIFF
--- a/graph/auth.go
+++ b/graph/auth.go
@@ -13,7 +13,8 @@ import (
 )
 
 type (
-	userKey struct{}
+	userKey    struct{}
+	requestKey struct{}
 
 	UserContext struct {
 		Username string     `json:"username"`

--- a/graph/handler.go
+++ b/graph/handler.go
@@ -46,6 +46,7 @@ func getClientIP(r *http.Request) string {
 	if colonIndex := strings.LastIndex(ip, ":"); colonIndex != -1 {
 		ip = ip[:colonIndex]
 	}
+	ip = strings.Trim(ip, "[]")
 	return ip
 }
 


### PR DESCRIPTION
- Only show error field when errors exist
- Add client IP to logs with proxy/CDN support
- Use short field names to reduce log verbosity